### PR TITLE
Extend default equities start date to 1970 from 1990

### DIFF
--- a/trading_calendars/trading_calendar.py
+++ b/trading_calendars/trading_calendar.py
@@ -40,7 +40,7 @@ from .utils.memoize import lazyval
 from .utils.pandas_utils import days_at_time
 
 
-start_default = pd.Timestamp('1990-01-01', tz=UTC)
+start_default = pd.Timestamp('1970-01-01', tz=UTC)
 end_base = pd.Timestamp('today', tz=UTC)
 # Give an aggressive buffer for logic that needs to use the next trading
 # day or minute.


### PR DESCRIPTION
Trading_calendars by Quantopian had a start date of 1990 because they had not fully defined holidays before that it was originally developed.

This PR sets the start date to 1970-01-01 so that bundles can be ingested that go back to that date.

It has not been extended prior to this beacuse there are many prior-to-Unix-epoch-related issues in various packages that would break as a result.
